### PR TITLE
Sklearn compatibility

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2,11 +2,11 @@ API
 ===
 
 
-The API for :py:class:`multispaeti.MultispatiPCA` tries to follow the design in
-`scikit-learn <https://scikit-learn.org/>`_. The plan is to make it fully compatible in
-the future by inheriting from :py:class:`sklearn.base.BaseEstimator` and
-:py:class:`sklearn.base.TransformerMixin`.
-
+The API for :py:class:`multispaeti.MultispatiPCA` follows the design in
+`scikit-learn <https://scikit-learn.org/>`_. It inherits from
+:py:class:`sklearn.base.BaseEstimator`, :py:class:`sklearn.base.TransformerMixin`, and
+:py:class:`sklearn.base.ClassNamePrefixFeaturesOutMixin` making it fully compatible
+with `scikit-learn` pipelines.
 
 
 .. currentmodule:: multispaeti

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -39,7 +39,8 @@ As for e.g. :py:class:`sklearn.decomposition.PCA` we first need to
 
 
 Alternatively, this can be achieved in one step by
-:py:meth:`multispaeti.MultispatiPCA.fit_transform`
+:py:meth:`multispaeti.MultispatiPCA.fit_transform` which is also more performant and
+avoids redundant computation
 
 .. code-block:: python
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -43,7 +43,7 @@ As for e.g. :py:class:`sklearn.decomposition.PCA` we first need to
 .. note::
 
     MultispatiPCA expects its input to be standardized by e.g. using
-    :py:func:`sklearn.decomposition.scale` before passing it to fit/transform.
+    :py:func:`sklearn.preprocessing.scale` before passing it to fit/transform.
 
 
 Alternatively, this can be achieved in one step by

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -34,16 +34,8 @@ As for e.g. :py:class:`sklearn.decomposition.PCA` we first need to
 
 .. code-block:: python
 
-    from sklearn.preprocessing import scale
-
-    X_scaled = scale(X)
-    msPCA.fit(X_scaled)
-    X_transformed = msPCA.transform(X_scaled)
-
-.. note::
-
-    MultispatiPCA expects its input to be standardized by e.g. using
-    :py:func:`sklearn.preprocessing.scale` before passing it to fit/transform.
+    msPCA.fit(X)
+    X_transformed = msPCA.transform(X)
 
 
 Alternatively, this can be achieved in one step by
@@ -51,7 +43,7 @@ Alternatively, this can be achieved in one step by
 
 .. code-block:: python
 
-    X_transformed = msPCA.fit_transform(X_scaled)
+    X_transformed = msPCA.fit_transform(X)
 
 .. Additional, functionality is offered through the method
 .. :py:meth:`multispaeti.MultispatiPCA.moransI_bounds` which calculates the minimum and

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -34,15 +34,24 @@ As for e.g. :py:class:`sklearn.decomposition.PCA` we first need to
 
 .. code-block:: python
 
-    msPCA.fit(X)
-    X_transformed = msPCA.transform(X)
+    from sklearn.preprocessing import scale
+
+    X_scaled = scale(X)
+    msPCA.fit(X_scaled)
+    X_transformed = msPCA.transform(X_scaled)
+
+.. note::
+
+    MultispatiPCA expects its input to be standardized by e.g. using
+    :py:func:`sklearn.decomposition.scale` before passing it to fit/transform.
+
 
 Alternatively, this can be achieved in one step by
 :py:meth:`multispaeti.MultispatiPCA.fit_transform`
 
 .. code-block:: python
 
-    X_transformed = msPCA.fit_transform(X)
+    X_transformed = msPCA.fit_transform(X_scaled)
 
 .. Additional, functionality is offered through the method
 .. :py:meth:`multispaeti.MultispatiPCA.moransI_bounds` which calculates the minimum and

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -39,8 +39,7 @@ As for e.g. :py:class:`sklearn.decomposition.PCA` we first need to
 
 
 Alternatively, this can be achieved in one step by
-:py:meth:`multispaeti.MultispatiPCA.fit_transform` which is also more performant and
-avoids redundant computation
+:py:meth:`multispaeti.MultispatiPCA.fit_transform` which avoids redundant computation.
 
 .. code-block:: python
 

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -175,12 +175,6 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         self._validate_n_components(n, d)
 
         self.W_ = normalize(W, norm="l1")
-        assert isinstance(self.W_, csr_array)
-
-        if issparse(X):
-            X = csc_array(X)
-
-        assert isinstance(X, (np.ndarray, csc_array))
 
         if issparse(X):
             self.mean_ = None
@@ -286,9 +280,8 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         """
         check_is_fitted(self)
         X = check_array(X, accept_sparse=["csr", "csc"])
-        if self.mean_ is not None:
-            if not issparse(X):
-                X = X - self.mean_
+        if self.mean_ is not None and not issparse(X):
+            X = X - self.mean_
         return X @ self.components_.T
 
     def transform_spatial_lag(self, X: _X) -> np.ndarray:

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -51,6 +51,10 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         c\ :sub:`ij` should be larger if i and j are close.
         A distance matrix should be transformed to connectivities by e.g.
         calculating :math:`1-d/d_{max}` beforehand.
+    center_sparse : bool
+        Whether to center `X` if it is a sparse array. By default sparse `X` will not be
+        centered as this requires transforming it to a dense array, potentially raising
+        out-of-memory errors.
 
     Attributes
     ----------
@@ -94,9 +98,11 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         n_components: int | tuple[int, int] | None = None,
         *,
         connectivity: _Connectivity | None = None,
+        center_sparse: bool = False,
     ):
         self.n_components = n_components
         self.connectivity = connectivity
+        self.center_sparse = center_sparse
 
     @staticmethod
     def _validate_connectivity(W: _Connectivity, n: int):
@@ -179,6 +185,10 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         self._validate_n_components(n, d)
 
         self.W_ = normalize(W, norm="l1")
+
+        if self.center_sparse and issparse(X):
+            assert isinstance(X, (csr_array, csr_matrix, csc_array, csc_matrix))
+            X = X.toarray()
 
         if issparse(X):
             self.mean_ = None

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -201,7 +201,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         self.n_features_in_ = d
 
         self.variance_, self.moransI_ = self._variance_moransI_decomposition(
-            X @ self.components_
+            X @ self.components_.T
         )
 
         return self
@@ -262,7 +262,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                 eig_val = eig_val[component_indices]
                 eig_vec = eig_vec[:, component_indices]
 
-        return np.flip(eig_val), np.fliplr(eig_vec)
+        return np.flip(eig_val), np.flipud(eig_vec.T)
 
     @staticmethod
     def _get_component_indices(n: int, n_pos: int, n_neg: int) -> list[int]:
@@ -291,7 +291,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         """
         check_is_fitted(self)
         X = check_array(X)
-        return X @ self.components_
+        return X @ self.components_.T
 
     def transform_spatial_lag(self, X: _X) -> np.ndarray:
         """

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -148,13 +148,10 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         Raises
         ------
         ValueError
-            If `X` has not the same number of rows like `connectivity`.
+            If `X` does not have the same number of rows as `connectivity`.
             If `n_components` is None and `X` is sparse.
             If (sum of) `n_components` is larger than the smaller dimension of `X`.
-        ValueError
-            If connectivity is not a square matrix.
-        ZeroDivisionError
-            If one of the observations has no neighbors.
+            If `connectivity` is not a square matrix.
         """
 
         X = check_array(X)
@@ -289,7 +286,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
 
         Raises
         ------
-        ValueError
+        sklearn.exceptions.NotFittedError
             If instance has not been fitted.
         """
         check_is_fitted(self)
@@ -312,7 +309,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
 
         Raises
         ------
-        ValueError
+        sklearn.exceptions.NotFittedError
             If instance has not been fitted.
         """
         check_is_fitted(self)

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -362,12 +362,9 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         if not issparse(W) or not sparse_approx:
             W = double_center(W)
 
-        if issparse(W):
-            eigen_values = s * sparse_linalg.eigsh(
-                W, k=2, which="BE", return_eigenvectors=False
-            )
-        else:
-            eigen_values = s * linalg.eigvalsh(W, overwrite_a=True)
+        eigen_values = s * sparse_linalg.eigsh(
+            W, k=2, which="BE", return_eigenvectors=False
+        )
 
         I_0 = -1 / (n_sample - 1)
         I_min = min(eigen_values)

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -153,7 +153,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
             If `connectivity` is not a square matrix.
         """
 
-        X = check_array(X)
+        X = check_array(X, accept_sparse=["csr", "csc"])
         if self.connectivity is None:
             warnings.warn(
                 "`connectivity` has not been set. Defaulting to identity matrix "
@@ -297,7 +297,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
             If instance has not been fitted.
         """
         check_is_fitted(self)
-        X = check_array(X)
+        X = check_array(X, accept_sparse=["csr", "csc"])
         if self.mean_ is not None:
             if not issparse(X):
                 X = X - self.mean_

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -6,7 +6,6 @@ from numpy.typing import NDArray
 from scipy import linalg
 from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix, eye, issparse
 from scipy.sparse import linalg as sparse_linalg
-from scipy.sparse import sparray, spmatrix
 from sklearn.base import (
     BaseEstimator,
     ClassNamePrefixFeaturesOutMixin,
@@ -22,6 +21,7 @@ U = TypeVar("U", bound=np.number)
 _Csr: TypeAlias = csr_array | csr_matrix
 _Csc: TypeAlias = csc_array | csc_matrix
 _X: TypeAlias = np.ndarray | _Csr | _Csc
+_Connectivity: TypeAlias = np.ndarray | _Csr
 
 
 class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
@@ -93,13 +93,13 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         self,
         n_components: int | tuple[int, int] | None = None,
         *,
-        connectivity: sparray | spmatrix | None = None,
+        connectivity: _Connectivity | None = None,
     ):
         self.n_components = n_components
         self.connectivity = connectivity
 
     @staticmethod
-    def _validate_connectivity(W: csr_array, n: int):
+    def _validate_connectivity(W: _Connectivity, n: int):
         if W.shape[0] != W.shape[1]:
             raise ValueError("`connectivity` must be square")
         if W.shape[0] != n:
@@ -199,7 +199,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         return self
 
     def _multispati_eigendecomposition(
-        self, X: _X, W: _Csr
+        self, X: _X, W: _Connectivity
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         # X: observations x features
         # W: row-wise definition of neighbors, row-sums should be 1

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -225,7 +225,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                 case (0, n_neg):
                     eig_val, eig_vec = sparse_linalg.eigsh(H, k=n_neg, which="SA")
                 case (n_pos, n_neg):
-                    n_comp = max(2 * max(n_neg, n_pos), max(n, d))
+                    n_comp = min(2 * max(n_neg, n_pos), min(n, d))
                     eig_val, eig_vec = sparse_linalg.eigsh(H, k=n_comp, which="BE")
                     component_indices = self._get_component_indices(
                         n_comp, n_pos, n_neg

--- a/multispaeti/_plotting.py
+++ b/multispaeti/_plotting.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
+from sklearn.utils.validation import check_is_fitted
 
 from ._multispati_pca import MultispatiPCA
 
@@ -13,16 +14,21 @@ def plot_eigenvalues(msPCA: MultispatiPCA, *, n_top: int | None = None) -> Figur
     Parameters
     ----------
     msPCA : MultispatiPCA
-        An instance of MultispatiPCA that has already been used for
-        :py:meth:`multispaeti.MultispatiPCA.fit` so that eigenvalues have already been
-        calculated.
+        An instance of MultispatiPCA that has been fitted so that the eigenvalues
+        have been calculated.
     n_top : int, optional
         Plot the `n_top` highest and `n_top` lowest eigenvalues in a zoomed in view.
 
     Returns
     -------
     matplotlib.figure.Figure
+
+    Raises
+    ------
+    sklearn.exceptions.NotFittedError
+        If the MultispatiPCA has not been fitted.
     """
+    check_is_fitted(msPCA)
     eigenvalues = msPCA.eigenvalues_
 
     x_lbl, y_lbl = "Component", "Eigenvalue"
@@ -66,17 +72,23 @@ def plot_variance_moransI_decomposition(
     Parameters
     ----------
     msPCA : multispaeti.MultispatiPCA
-        An instance of MultispatiPCA that has already been used for
-        :py:meth:`multispaeti.MultispatiPCA.transform` so that variance and Moran's I
-        contributions to the eigenvalues have already been calculated.
+        An instance of MultispatiPCA that has been fitted so that variance and Moran's I
+        contributions to the eigenvalues have been calculated.
     sparse_approx : bool
         Whether to use a sparse approximation to calculate the decomposition.
+    kwargs
+        Other keyword arguments are passed to :py:func:`matplotlib.pyplot.scatter`
 
     Returns
     -------
     matplotlib.figure.Figure
-    """
 
+    Raises
+    ------
+    sklearn.exceptions.NotFittedError
+        If the MultispatiPCA has not been fitted.
+    """
+    check_is_fitted(msPCA)
     I_min, I_max, I_0 = msPCA.moransI_bounds(sparse_approx=sparse_approx)
 
     fig, ax = plt.subplots(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 [project.optional-dependencies]
 test = ["pytest"]
 docs = ["sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
-dev  = ["multispaeti[docs]", "pre-commit"]
+dev  = ["multispaeti[test,docs]", "pre-commit"]
 
 [project.urls]
 homepage      = "https://github.com/HiDiHlabs/multiSPAETI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic         = ["version"]
 authors = [
     { name = "Niklas Müller-Bötticher", email = "niklas.mueller-boetticher@charite.de" },
 ]
-dependencies = ["matplotlib", "numpy>=1.21", "scikit-learn", "scipy>=1.9"]
+dependencies = ["matplotlib>=3.6", "numpy>=1.23", "scikit-learn>=1.1", "scipy>=1.9"]
 classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+test = ["pytest"]
 docs = ["sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
 dev  = ["multispaeti[docs]", "pre-commit"]
 
@@ -56,3 +57,7 @@ target-version = "py310"
 ignore_missing_imports = true
 warn_no_return         = false
 packages               = "multispaeti"
+
+[tool.pytest.ini_options]
+addopts    = ["--import-mode=importlib"]
+pythonpath = "multispaeti"

--- a/tests/test_multispati_pca.py
+++ b/tests/test_multispati_pca.py
@@ -1,0 +1,11 @@
+import pytest
+from sklearn.utils.estimator_checks import check_estimator
+
+from multispaeti import MultispatiPCA
+
+
+def test_sklearn_compatibility():
+    try:
+        check_estimator(MultispatiPCA())
+    except AssertionError:
+        pytest.fail("Failed check_estimator() test of sklearn.")


### PR DESCRIPTION
- Make `MultispatiPCA` fully compatible with sklearn by inheriting from `BaseEstimator` and `TransformerMixin` (as well as `ClassNamePrefixFeaturesOutMixin`)
- Allow retrieval of all components (using `n_components=None`) for sparse arrays (closes #6)
- Allow dense arrays as `connectivity`