### PR TITLE
Prepare eigendecomposition functionality for GPU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .venv
 .python-version
-build
 multispaeti.egg-info
 __pycache__
+
+.vscode
+
+# sphinx
+generated
+build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,8 @@ repos:
     rev: v1.11.2
     hooks:
       - id: mypy
+        additional_dependencies:
+          - "numpy"
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,26 +16,18 @@ repos:
       - id: no-commit-to-branch
         args: [--branch=main]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.9.9
     hooks:
       - id: ruff
-        args: [--fix]
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.15.0
     hooks:
       - id: mypy
         additional_dependencies:
           - "numpy"
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # multiSPAETI*
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![Docs](https://app.readthedocs.org/projects/multispaeti/badge/?version=latest)](https://multispaeti.readthedocs.io)
+[![PyPI](https://img.shields.io/pypi/v/multispaeti)](https://pypi.org/project/multispaeti)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/multispaeti)](https://anaconda.org/conda-forge/multispaeti)
+
 
 `multispaeti` is a Python implementation of
 [MULTISPATI-PCA](https://doi.org/10.3170/2007-8-18312) /

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,5 +17,6 @@ with `scikit-learn` pipelines.
    :template: class.rst
 
    MultispatiPCA
+   multispati_pca
    plot_eigenvalues
    plot_variance_moransI_decomposition

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ templates_path = ["_templates"]
 exclude_patterns: list[str] = []
 
 intersphinx_mapping = dict(
+    cupy=("https://docs.cupy.dev/en/stable/", None),
     matplotlib=("https://matplotlib.org/stable/", None),
     numpy=("https://numpy.org/doc/stable/", None),
     python=("https://docs.python.org/3", None),

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,6 +11,23 @@ To install ``multispaeti`` from `PyPI <https://pypi.org/>`_ using ``pip`` just r
 
     pip install multispaeti
 
+GPU support
+___________
+
+In most cases support for GPU computations (using `CuPy <https://cupy.dev/>`_) can be
+installed via
+
+.. code-block:: bash
+
+    # for CUDA12
+    pip install multispaeti[cuda12]
+
+    # or for CUDA11
+    pip install multispaeti[cuda11]
+
+However, in cases where this doesn't work we recommended referring to the
+`CuPy documentation <https://docs.cupy.dev/en/stable/install.html>`_.
+
 
 conda-forge and ``conda``
 -------------------------
@@ -25,6 +42,12 @@ conda-forge and ``conda``
 
     Of course, it is also possible to use ``mamba`` instead of ``conda``
     to speed up the installation.
+
+GPU support
+___________
+
+For support of GPU computations please refer to the
+`CuPy documentation <https://docs.cupy.dev/en/stable/install.html>`_.
 
 
 From GitHub

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -45,6 +45,18 @@ Alternatively, this can be achieved in one step by
 
     X_transformed = msPCA.fit_transform(X)
 
+If only the transformed data matrix and selected components are of interest, the most
+efficient is to call :py:func:`multispaeti.multispati_pca` directly as this will avoid
+calculating additional statistics such as variance and Moran's I.
+
+.. code-block:: python
+
+    from multispaeti import multispati_pca
+
+    X_transformed, components = multispati_pca(
+        X, n_components=(30, 5), connectivity=connectivity
+    )
+
 .. Additional, functionality is offered through the method
 .. :py:meth:`multispaeti.MultispatiPCA.moransI_bounds` which calculates the minimum and
 .. maximum bound as well as the expected value given the `connectivity` matrix

--- a/multispaeti/__init__.py
+++ b/multispaeti/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from ._multispati_pca import MultispatiPCA
+from ._multispati_pca import MultispatiPCA, multispati_pca
 from ._plotting import plot_eigenvalues, plot_variance_moransI_decomposition
 
 try:
@@ -11,4 +11,9 @@ except PackageNotFoundError:
 del PackageNotFoundError, version
 
 
-__all__ = ["MultispatiPCA", "plot_eigenvalues", "plot_variance_moransI_decomposition"]
+__all__ = [
+    "MultispatiPCA",
+    "multispati_pca",
+    "plot_eigenvalues",
+    "plot_variance_moransI_decomposition",
+]

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -281,8 +281,8 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                     eig_val_hi, eig_vec_hi = sparse_linalg.eigsh(H, k=n_pos, which="LA")
                     eig_val_lo, eig_vec_lo = sparse_linalg.eigsh(H, k=n_neg, which="SA")
 
-                    eig_val = self._xp.concatenate(eig_val_hi, eig_val_lo)
-                    eig_vec = self._xp.concatenate(eig_vec_hi, eig_vec_lo)
+                    eig_val = self._xp.concatenate([eig_val_lo, eig_val_hi])
+                    eig_vec = self._xp.concatenate([eig_vec_lo, eig_vec_hi], axis=1)
 
         # numpy.ndarray
         elif self._xp.__name__ != "cupy":

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -447,7 +447,11 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
             W = double_center(W)
 
         I_0 = -1 / (n_sample - 1)
-        I_min = s * sparse_linalg.eigsh(W, k=1, which="SA", return_eigenvectors=False)
-        I_max = s * sparse_linalg.eigsh(W, k=1, which="LA", return_eigenvectors=False)
+        I_min = (
+            s * sparse_linalg.eigsh(W, k=1, which="SA", return_eigenvectors=False)[0]
+        )
+        I_max = (
+            s * sparse_linalg.eigsh(W, k=1, which="LA", return_eigenvectors=False)[0]
+        )
 
         return I_min, I_max, I_0

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -115,7 +115,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         connectivity: _Connectivity | None = None,
         center_sparse: bool = False,
         use_gpu: bool = False,
-    ) -> None:
+    ):
         self.n_components = n_components
         self.connectivity = connectivity
         self.center_sparse = center_sparse
@@ -127,7 +127,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         return tags
 
     @staticmethod
-    def _validate_connectivity(W: _Connectivity, n: int) -> None:
+    def _validate_connectivity(W: _Connectivity, n: int):
         if W.shape[0] != W.shape[1]:
             raise ValueError("`connectivity` must be square")
         if W.shape[0] != n:
@@ -135,7 +135,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                 "#rows in `X` must be the same as dimensions of `connectivity`"
             )
 
-    def _validate_n_components(self, n: int, d: int) -> None:
+    def _validate_n_components(self, n: int, d: int):
         self._n_components = self.n_components
 
         m = min(n, d)

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -1,6 +1,6 @@
 import warnings
 from types import ModuleType
-from typing import TYPE_CHECKING, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Self, TypeAlias, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -151,7 +151,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
             else:
                 raise ValueError("`n_components` must be None, int or (int, int)")
 
-    def fit(self, X: _X, y: None = None, use_gpu: bool = False) -> "MultispatiPCA":
+    def fit(self, X: _X, y: None = None, use_gpu: bool = False) -> Self:
         """
         Fit MULTISPATI-PCA projection.
 

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -393,7 +393,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
 
     def _variance_moransI_decomposition(
         self, X_tr: "np.ndarray | cp.ndarray"
-    ) -> tuple[np.ndarray, np.ndarray] | tuple["cp.ndarray", "cp.ndarray"]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         lag = self._spatial_lag(X_tr)
 
         xp = np if not self.use_gpu else cp

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -197,7 +197,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
     def _fit(
         self, X: _X, *, return_transform: bool = False, stats: bool = True
     ) -> "np.ndarray | cp.ndarray | None":
-        X = check_array(X, accept_sparse=["csr", "csc"])
+        X = validate_data(self, X, reset=False, accept_sparse=["csr", "csc"])
         if self.connectivity is None:
             warnings.warn(
                 "`connectivity` has not been set. Defaulting to identity matrix "

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -48,10 +48,10 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         If an int, it will keep the top `n_components`.
         If a tuple, it will keep the top and bottom `n_components`, respectively.
     connectivity : scipy.sparse.sparray or scipy.sparse.spmatrix
-        Matrix of row-wise neighbor definitions i.e. c\ :sub:`ij` is the connectivity of
+        Matrix of row-wise neighbor definitions i.e. c\\ :sub:`ij` is the connectivity of
         i :math:`\\to` j. The matrix does not have to be symmetric. It can be a
         binary adjacency matrix or a matrix of connectivities in which case
-        c\ :sub:`ij` should be larger if i and j are close.
+        c\\ :sub:`ij` should be larger if i and j are close.
         A distance matrix should be transformed to connectivities by e.g.
         calculating :math:`1-d/d_{max}` beforehand.
     center_sparse : bool
@@ -195,9 +195,9 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         return self
 
     def _fit(
-        self, X: _X, *, return_transform: bool = False
+        self, X: _X, *, return_transform: bool = False, stats: bool = True
     ) -> "np.ndarray | cp.ndarray | None":
-        X = validate_data(self, X, accept_sparse=["csr", "csc"])
+        X = check_array(X, accept_sparse=["csr", "csc"])
         if self.connectivity is None:
             warnings.warn(
                 "`connectivity` has not been set. Defaulting to identity matrix "
@@ -236,8 +236,9 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         self._n_features_out = self.n_components_
         self.n_features_in_ = d
 
-        X_tr = X_centered @ self.components_.T
-        self.variance_, self.moransI_ = self._variance_moransI_decomposition(X_tr)  # type: ignore
+        if stats:
+            X_tr = X_centered @ self.components_.T
+            self.variance_, self.moransI_ = self._variance_moransI_decomposition(X_tr)
 
         if return_transform:
             return X_tr
@@ -293,7 +294,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                         H, subset_by_index=[d - n_pos, d - 1]
                     )
                 case (0, n_neg):
-                    eig_val, eig_vec = linalg.eigh(H, subset_by_index=[0, n_neg])
+                    eig_val, eig_vec = linalg.eigh(H, subset_by_index=[0, n_neg - 1])
                 case (n_pos, n_neg):
                     eig_val, eig_vec = linalg.eigh(H)
                     component_indices = self._get_component_indices(d, n_pos, n_neg)
@@ -459,3 +460,53 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         )
 
         return I_min, I_max, I_0
+
+
+def multispati_pca(
+    X: _X,
+    n_components: int | tuple[int, int] | None = None,
+    *,
+    connectivity: _Connectivity | None = None,
+    center_sparse: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate MULTISPATI-PCA and return the transformed data matrix and components.
+
+    For more information refer to :py:class:`multispaeti.MultispatiPCA`.
+
+    This function is more efficient than :py:meth:`multispaeti.MultispatiPCA.fit_transform`
+    if the additional attributes are not needed.
+
+    Parameters
+    ----------
+    X : numpy.ndarray or scipy.sparse.csr_array or scipy.sparse.csc_array
+        Array of observations x features.
+    n_components : int or tuple[int, int], optional
+        Number of components to keep.
+        If None, will keep all components.
+        If an int, it will keep the top `n_components`.
+        If a tuple, it will keep the top and bottom `n_components`, respectively.
+    connectivity : scipy.sparse.sparray or scipy.sparse.spmatrix
+        Matrix of row-wise neighbor definitions i.e. c\\ :sub:`ij` is the connectivity of
+        i :math:`\\to` j. The matrix does not have to be symmetric. It can be a
+        binary adjacency matrix or a matrix of connectivities in which case
+        c\\ :sub:`ij` should be larger if i and j are close.
+        A distance matrix should be transformed to connectivities by e.g.
+        calculating :math:`1-d/d_{max}` beforehand.
+    center_sparse : bool
+        Whether to center `X` if it is a sparse array. By default sparse `X` will not be
+        centered as this requires transforming it to a dense array, potentially raising
+        out-of-memory errors.
+
+    Returns
+    -------
+        X_transformed : numpy.ndarray
+        components : numpy.ndarray
+    """
+    ms_pca = MultispatiPCA(
+        n_components, connectivity=connectivity, center_sparse=center_sparse
+    )
+
+    X_tr = ms_pca._fit(X, return_transform=True, stats=False)
+    assert isinstance(X_tr, np.ndarray)
+    return X_tr, ms_pca.components_

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -198,7 +198,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         return self
 
     def _fit(self, X: _X, *, return_transform: bool = False) -> np.ndarray | None:
-        X = check_array(X, accept_sparse=["csr", "csc"])
+        X = validate_data(self, X, accept_sparse=["csr", "csc"])
         if self.connectivity is None:
             warnings.warn(
                 "`connectivity` has not been set. Defaulting to identity matrix "
@@ -343,13 +343,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
             If instance has not been fitted.
         """
         check_is_fitted(self)
-        X = validate_data(
-            self,
-            X,
-            reset=False,
-            skip_check_array=False,
-            check_params={"accept_sparse": ["csr", "csc"]},
-        )
+        X = validate_data(self, X, reset=False, accept_sparse=["csr", "csc"])
         if self.mean_ is not None and not issparse(X):
             X = X - self.mean_
         return X @ self.components_.T

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -446,16 +446,16 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         W = 0.5 * (self.W_ + self.W_.T)
 
         n_sample = W.shape[0]
-        s = n_sample / self._xp.sum(W)  # 1 if original W has rowSums or colSums of 1
+        s = n_sample / W.sum()  # 1 if original W has rowSums or colSums of 1
 
         if not issparse(W) or not sparse_approx:
             W = double_center(W)
 
         I_0 = -1 / (n_sample - 1)
-        I_min = (
+        I_min = float(
             s * sparse_linalg.eigsh(W, k=1, which="SA", return_eigenvectors=False)[0]
         )
-        I_max = (
+        I_max = float(
             s * sparse_linalg.eigsh(W, k=1, which="LA", return_eigenvectors=False)[0]
         )
 

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -59,6 +59,9 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         Whether to center `X` if it is a sparse array. By default sparse `X` will not be
         centered as this requires transforming it to a dense array, potentially raising
         out-of-memory errors.
+    use_gpu : bool
+        Whether to use the GPU for computations. Requires `cupy` to be installed.
+        TODO: add link to install instructions or similar
 
     Attributes
     ----------
@@ -103,11 +106,12 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         *,
         connectivity: _Connectivity | None = None,
         center_sparse: bool = False,
+        use_gpu: bool = False,
     ) -> None:
         self.n_components = n_components
         self.connectivity = connectivity
         self.center_sparse = center_sparse
-        self.use_gpu = False
+        self.use_gpu = use_gpu
         self.xp: ModuleType = np
 
     @staticmethod

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -130,6 +130,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                         "#samples and #features. Using all components."
                     )
                     self._n_components = None
+                self._n_components = (self.n_components, 0)
             elif isinstance(self.n_components, tuple) and len(self.n_components) == 2:
                 if any(
                     not isinstance(i, int) or i < 0 for i in self.n_components
@@ -260,7 +261,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                     eig_val, eig_vec = sparse_linalg.eigsh(
                         H, k=min(n, d) - 1, which="LM"
                     )
-                case (n_pos, 0) | int(n_pos):
+                case (n_pos, 0):
                     eig_val, eig_vec = sparse_linalg.eigsh(H, k=n_pos, which="LA")
                 case (0, n_neg):
                     eig_val, eig_vec = sparse_linalg.eigsh(H, k=n_neg, which="SA")
@@ -279,7 +280,7 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                     eig_val, eig_vec = linalg.eigh(H)
                     if n < d:
                         eig_val, eig_vec = remove_zero_eigenvalues(eig_val, eig_vec, n)
-                case (n_pos, 0) | int(n_pos):
+                case (n_pos, 0):
                     eig_val, eig_vec = linalg.eigh(
                         H, subset_by_index=[d - n_pos, d - 1]
                     )

--- a/multispaeti/_multispati_pca.py
+++ b/multispaeti/_multispati_pca.py
@@ -113,6 +113,11 @@ class MultispatiPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         self.center_sparse = center_sparse
         self.use_gpu = use_gpu
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
+
     @staticmethod
     def _validate_connectivity(W: _Connectivity, n: int) -> None:
         if W.shape[0] != W.shape[1]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic         = ["version"]
 authors = [
     { name = "Niklas Müller-Bötticher", email = "niklas.mueller-boetticher@charite.de" },
 ]
-dependencies = ["numpy>=1.23", "scikit-learn>=1.1", "scipy>=1.9"]
+dependencies = ["numpy>=1.23", "scikit-learn>=1.6", "scipy>=1.9"]
 classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ include = ["multispaeti"]
 profile = "black"
 
 [tool.black]
-target-version = ["py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.ruff]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ license         = { file = "LICENSE" }
 requires-python = ">=3.11"
 dynamic         = ["version"]
 
-authors = [
-    { name = "Niklas Müller-Bötticher", email = "niklas.mueller-boetticher@charite.de" },
-]
+authors = [{ name = "Niklas Müller-Bötticher", email = "niklas.mueller-boetticher@charite.de" }]
 dependencies = ["numpy>=1.25", "scikit-learn>=1.6", "scipy>=1.11"]
 classifiers = [
     "Intended Audience :: Science/Research",
@@ -26,10 +24,12 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-plot = ["matplotlib>=3.8"]
-test = ["pytest"]
-docs = ["sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
-dev  = ["multispaeti[plot,test,docs]", "pre-commit"]
+cuda11 = ["cupy-cuda11x>=13"]
+cuda12 = ["cupy-cuda12x>=13"]
+plot   = ["matplotlib>=3.8"]
+test   = ["pytest"]
+docs   = ["sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
+dev    = ["multispaeti[plot,test,docs]", "pre-commit"]
 
 [project.urls]
 Homepage      = "https://github.com/HiDiHlabs/multiSPAETI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,15 +45,14 @@ include = ["multispaeti"]
 
 [tool.setuptools_scm]
 
-
-[tool.isort]
-profile = "black"
-
-[tool.black]
-target-version = ["py311", "py312", "py313"]
-
 [tool.ruff]
 target-version = "py311"
+
+fix        = true
+show-fixes = true
+
+[tool.ruff.lint]
+extend-select = ["I"]
 
 [tool.mypy]
 python_version         = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name            = "multispaeti"
 description     = "Implementation of MULTISPATI-PCA in python"
 readme          = { file = "README.md", content-type = "text/markdown" }
 license         = { file = "LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dynamic         = ["version"]
 
 authors = [
@@ -50,13 +50,13 @@ include = ["multispaeti"]
 profile = "black"
 
 [tool.black]
-target-version = ["py310", "py311", "py312", "py313"]
+target-version = ["py311", "py312", "py313"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 
 [tool.mypy]
-python_version         = "3.10"
+python_version         = "3.11"
 ignore_missing_imports = true
 warn_no_return         = false
 packages               = "multispaeti"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic         = ["version"]
 authors = [
     { name = "Niklas Müller-Bötticher", email = "niklas.mueller-boetticher@charite.de" },
 ]
-dependencies = ["numpy>=1.23", "scikit-learn>=1.6", "scipy>=1.9"]
+dependencies = ["numpy>=1.25", "scikit-learn>=1.6", "scipy>=1.11"]
 classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-plot = ["matplotlib>=3.6"]
+plot = ["matplotlib>=3.8"]
 test = ["pytest"]
 docs = ["sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
 dev  = ["multispaeti[plot,test,docs]", "pre-commit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,11 @@ target-version = ["py310", "py311", "py312", "py313"]
 target-version = "py310"
 
 [tool.mypy]
+python_version         = "3.10"
 ignore_missing_imports = true
 warn_no_return         = false
 packages               = "multispaeti"
+plugins                = "numpy.typing.mypy_plugin"
 
 [tool.pytest.ini_options]
 addopts    = ["--import-mode=importlib"]


### PR DESCRIPTION
Updated some dependencies
eigen decomposition for the GPU prepared to work with the reduced functionality of cupy compared to scipy

I also renamed `self.xp` to `self._xp` as usually the attributes in sklearn are the ones entered in the `__init__`, furthermore this parameter should generally not be adjusted by the user.

I am not entirely sure yet whether we should use `sklearn.utils.validate.validate_data` as this has only been introduced in the latest release which is only few weeks old.